### PR TITLE
Problem: WalletConnect implementation doesn't handle session updates (fixes #2)

### DIFF
--- a/wallet-connect/src/client/session.rs
+++ b/wallet-connect/src/client/session.rs
@@ -75,8 +75,12 @@ impl Session {
     /// updates the session details from the session update: https://docs.walletconnect.com/tech-spec#session-update
     pub fn update(&mut self, update: SessionUpdate) {
         self.connected = update.approved;
-        self.accounts = update.accounts;
-        self.chain_id = Some(update.chain_id);
+        if let Some(accounts) = update.accounts {
+            self.accounts = accounts;
+        } else {
+            self.accounts = vec![];
+        }
+        self.chain_id = update.chain_id;
     }
 }
 


### PR DESCRIPTION
Solution: added basic handling of session update requests
as per https://docs.walletconnect.com/tech-spec#session-update
tested with https://test.walletconnect.org/ and Trust Wallet
(one thing discored is that for disconnecting, chain_id and accounts
will be null, hence the change of the corresponding field types)