### PR TITLE
Problem: missing contract transaction history (fixes #19)

### DIFF
--- a/extra-cpp-bindings/src/lib.rs
+++ b/extra-cpp-bindings/src/lib.rs
@@ -27,6 +27,11 @@ mod ffi {
         pub contract_address: String,
     }
 
+    pub enum QueryOption {
+        ByContract,
+        ByAddressAndContract,
+    }
+
     extern "Rust" {
         pub fn get_transaction_history_blocking(
             address: String,
@@ -35,15 +40,19 @@ mod ffi {
         pub fn get_erc20_transfer_history_blocking(
             address: String,
             contract_address: String,
+            option: QueryOption,
             api_key: String,
         ) -> Result<Vec<RawTxDetail>>;
         pub fn get_erc721_transfer_blocking(
             address: String,
             contract_address: String,
+            option: QueryOption,
             api_key: String,
         ) -> Result<Vec<RawTxDetail>>;
     }
 }
+
+use ffi::{QueryOption, RawTxDetail};
 
 /// returns the transactions of a given address.
 /// The API key can be obtained from https://cronoscan.com
@@ -56,32 +65,36 @@ pub fn get_transaction_history_blocking(
 }
 
 /// returns the ERC20 transfers of a given address of a given contract.
+/// (address can be empty if option is ByContract)
+/// default option is by address
 /// The API key can be obtained from https://cronoscan.com
 pub fn get_erc20_transfer_history_blocking(
     address: String,
     contract_address: String,
+    option: QueryOption,
     api_key: String,
 ) -> Result<Vec<RawTxDetail>> {
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(
-        async move { get_erc20_transfer_history(&address, &contract_address, api_key).await },
-    )
+    rt.block_on(async move {
+        get_erc20_transfer_history(&address, &contract_address, option, api_key).await
+    })
 }
 
 /// returns the ERC721 transfers of a given address of a given contract.
+/// (address can be empty if option is ByContract)
+/// default option is by address
 /// The API key can be obtained from https://cronoscan.com
 pub fn get_erc721_transfer_blocking(
     address: String,
     contract_address: String,
+    option: QueryOption,
     api_key: String,
 ) -> Result<Vec<RawTxDetail>> {
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(
-        async move { get_erc721_transfer_history(&address, &contract_address, api_key).await },
-    )
+    rt.block_on(async move {
+        get_erc721_transfer_history(&address, &contract_address, option, api_key).await
+    })
 }
-
-use ffi::RawTxDetail;
 
 impl From<&NormalTransaction> for RawTxDetail {
     fn from(tx: &NormalTransaction) -> Self {
@@ -150,11 +163,17 @@ async fn get_transaction_history(address: &str, api_key: String) -> Result<Vec<R
 async fn get_erc20_transfer_history(
     address: &str,
     contract_address: &str,
+    option: QueryOption,
     api_key: String,
 ) -> Result<Vec<RawTxDetail>> {
     let client = Client::new(Chain::Cronos, api_key)?;
-    let token_query =
-        TokenQueryOption::ByAddressAndContract(address.parse()?, contract_address.parse()?);
+    let token_query = match option {
+        QueryOption::ByContract => TokenQueryOption::ByContract(contract_address.parse()?),
+        QueryOption::ByAddressAndContract => {
+            TokenQueryOption::ByAddressAndContract(address.parse()?, contract_address.parse()?)
+        }
+        _ => TokenQueryOption::ByAddress(address.parse()?),
+    };
     let transactions = client
         .get_erc20_token_transfer_events(token_query, None)
         .await?;
@@ -164,11 +183,17 @@ async fn get_erc20_transfer_history(
 async fn get_erc721_transfer_history(
     address: &str,
     contract_address: &str,
+    option: QueryOption,
     api_key: String,
 ) -> Result<Vec<RawTxDetail>> {
     let client = Client::new(Chain::Cronos, api_key)?;
-    let token_query =
-        TokenQueryOption::ByAddressAndContract(address.parse()?, contract_address.parse()?);
+    let token_query = match option {
+        QueryOption::ByContract => TokenQueryOption::ByContract(contract_address.parse()?),
+        QueryOption::ByAddressAndContract => {
+            TokenQueryOption::ByAddressAndContract(address.parse()?, contract_address.parse()?)
+        }
+        _ => TokenQueryOption::ByAddress(address.parse()?),
+    };
     let transactions = client
         .get_erc721_token_transfer_events(token_query, None)
         .await?;


### PR DESCRIPTION
Solution: extended the history call bindings for ERC721 and ERC20