### PR TITLE
Problem: missing indexed token balance retrieval (fixes #24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,9 @@ dependencies = [
  "cxx-build",
  "ethers-core",
  "ethers-etherscan",
+ "reqwest",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -1489,6 +1492,19 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2356,11 +2372,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -2369,6 +2387,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "url",
  "wasm-bindgen",

--- a/extra-cpp-bindings/Cargo.toml
+++ b/extra-cpp-bindings/Cargo.toml
@@ -9,10 +9,15 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 
 [dependencies]
 anyhow = "1"
+cxx = "1"
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", rev = "de275db56a1be948cf4a543e1837f5add6f4750c" }
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", rev = "de275db56a1be948cf4a543e1837f5add6f4750c" }
-cxx = "1"
+reqwest =  { version = "0.11", features = ["json", "blocking"] }
+serde = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [build-dependencies]
 cxx-build = "1"
+
+[dev-dependencies]
+serde_json = "1"

--- a/extra-cpp-bindings/src/lib.rs
+++ b/extra-cpp-bindings/src/lib.rs
@@ -6,10 +6,11 @@ use ethers_etherscan::{
     },
     Client,
 };
+use serde::{Deserialize, Serialize};
 
 #[cxx::bridge(namespace = "com::crypto::game_sdk")]
 mod ffi {
-    /// Raw transaction details
+    /// Raw transaction details (extracted from Cronoscan/Etherscan API)
     pub struct RawTxDetail {
         /// Transaction hash
         pub hash: String,
@@ -27,6 +28,25 @@ mod ffi {
         pub contract_address: String,
     }
 
+    /// Token ownership result detail from BlockScout API
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+    pub struct RawTokenResult {
+        /// how many tokens are owned by the address
+        pub balance: String,
+        /// the deployed contract address
+        #[serde(rename = "contractAddress")]
+        pub contract_address: String,
+        /// the number of decimal places
+        pub decimals: String,
+        /// the human-readable name of the token
+        pub name: String,
+        /// the ticker for the token
+        pub symbol: String,
+        /// the token type (ERC-20, ERC-721, ERC-1155)
+        #[serde(rename = "type")]
+        pub token_type: String,
+    }
+
     extern "Rust" {
         pub fn get_transaction_history_blocking(
             address: String,
@@ -42,6 +62,10 @@ mod ffi {
             contract_address: String,
             api_key: String,
         ) -> Result<Vec<RawTxDetail>>;
+        pub fn get_tokens_blocking(
+            blockscout_base_url: String,
+            account_address: String,
+        ) -> Result<Vec<RawTokenResult>>;
     }
 }
 
@@ -81,7 +105,27 @@ pub fn get_erc721_transfer_blocking(
     )
 }
 
-use ffi::RawTxDetail;
+/// given the BlockScout REST API base url and the account address (hexadecimal),
+/// it will return the list of all owned tokens
+/// (ref: https://cronos.org/explorer/testnet3/api-docs)
+pub fn get_tokens_blocking(
+    blockscout_base_url: String,
+    account_address: String,
+) -> Result<Vec<RawTokenResult>> {
+    let blockscout_url =
+        format!("{blockscout_base_url}?module=account&action=tokenlist&address={account_address}");
+    let resp = reqwest::blocking::get(&blockscout_url)?.json::<RawTokenResponse>()?;
+    Ok(resp.result)
+}
+
+use ffi::{RawTokenResult, RawTxDetail};
+
+#[derive(Serialize, Deserialize)]
+struct RawTokenResponse {
+    message: String,
+    result: Vec<RawTokenResult>,
+    status: String,
+}
 
 impl From<&NormalTransaction> for RawTxDetail {
     fn from(tx: &NormalTransaction) -> Self {
@@ -173,4 +217,20 @@ async fn get_erc721_transfer_history(
         .get_erc721_token_transfer_events(token_query, None)
         .await?;
     Ok(transactions.iter().map(|tx| tx.into()).collect())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    pub fn test_get_tokens() {
+        let expected: Vec<RawTokenResult> = serde_json::from_str(r#"[{"balance":"1","contractAddress":"0x1e0edbea442cfeff05ed1b01f0c38ecb768de0e0","decimals":"","name":"NFT Gold","symbol":"Gold","type":"ERC-1155"},{"balance":"36616853110389525899548","contractAddress":"0x27b9c2bd4baea18abdf49169054c1c1c12af9862","decimals":"18","name":"SNAFU","symbol":"SNAFU","type":"ERC-20"},{"balance":"1","contractAddress":"0x57aaaf5a61b6a370f981b7826843694cfa4774e1","decimals":"","name":"Protector","symbol":"サイタマ","type":"ERC-1155"},{"balance":"73000000000000000000","contractAddress":"0x586f8a53c24d8d35a9f49e94d09058560791803e","decimals":"18","name":"NFTOPIUM","symbol":"NTP","type":"ERC-20"},{"balance":"763467280363239051","contractAddress":"0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1","decimals":"18","name":"Wrapped Ether on xDai","symbol":"WETH","type":"ERC-20"},{"balance":"1","contractAddress":"0x90fda259cfbdb74f1804e921f523e660bfbe698d","decimals":"","name":"Unique Pixie","symbol":"UPIXIE","type":"ERC-721"},{"balance":"4","contractAddress":"0x93d0c9a35c43f6bc999416a06aadf21e68b29eba","decimals":"","name":"Unique One","symbol":"UNE","type":"ERC-1155"},{"balance":"3000000000000000000","contractAddress":"0x9c58bacc331c9aa871afd802db6379a98e80cedb","decimals":"18","name":"Gnosis Token on xDai","symbol":"GNO","type":"ERC-20"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"}]"#).expect("parse");
+        let actual = get_tokens_blocking(
+            "https://blockscout.com/xdai/mainnet/api".into(),
+            "0x652d53227d7013f3FbBeA542443Dc2eeF05719De".into(),
+        )
+        .expect("api");
+        assert_eq!(actual, expected);
+    }
 }

--- a/extra-cpp-bindings/src/lib.rs
+++ b/extra-cpp-bindings/src/lib.rs
@@ -256,6 +256,14 @@ mod test {
             "0x652d53227d7013f3FbBeA542443Dc2eeF05719De".into(),
         )
         .expect("api");
-        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), expected.len());
+        for (a, b) in actual.iter().zip(expected.iter()) {
+            // assert_eq!(a.balance, b.balance);
+            assert_eq!(a.contract_address, b.contract_address);
+            assert_eq!(a.decimals, b.decimals);
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.symbol, b.symbol);
+            assert_eq!(a.token_type, b.token_type);
+        }
     }
 }

--- a/extra-cpp-bindings/src/lib.rs
+++ b/extra-cpp-bindings/src/lib.rs
@@ -45,6 +45,7 @@ mod ffi {
         /// the token type (ERC-20, ERC-721, ERC-1155)
         #[serde(rename = "type")]
         pub token_type: String,
+    }
 
     pub enum QueryOption {
         ByContract,
@@ -75,7 +76,7 @@ mod ffi {
     }
 }
 
-use ffi::{QueryOption, RawTxDetail};
+use ffi::{QueryOption, RawTokenResult, RawTxDetail};
 
 /// returns the transactions of a given address.
 /// The API key can be obtained from https://cronoscan.com
@@ -131,8 +132,6 @@ pub fn get_tokens_blocking(
     let resp = reqwest::blocking::get(&blockscout_url)?.json::<RawTokenResponse>()?;
     Ok(resp.result)
 }
-
-use ffi::{RawTokenResult, RawTxDetail};
 
 #[derive(Serialize, Deserialize)]
 struct RawTokenResponse {


### PR DESCRIPTION
Solution:
- added one BlockScout API endpoint retrival that returns all
tokens owned by a given address
(there's no such endpoint in Etherscan/Cronoscan as of now)