### PR TITLE
Problem: missing ERC1155 token transfer history (fixes #36)

### DIFF
--- a/extra-cpp-bindings/src/lib.rs
+++ b/extra-cpp-bindings/src/lib.rs
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 
 #[cxx::bridge(namespace = "com::crypto::game_sdk")]
 mod ffi {
-    /// Raw transaction details (extracted from Cronoscan/Etherscan API)
+    /// Raw transaction details (extracted from Cronoscan/Etherscan or BlockScout API)
+    #[derive(Debug, PartialEq, Eq)]
     pub struct RawTxDetail {
         /// Transaction hash
         pub hash: String,
@@ -50,6 +51,7 @@ mod ffi {
     pub enum QueryOption {
         ByContract,
         ByAddressAndContract,
+        ByAddress,
     }
 
     extern "Rust" {
@@ -73,6 +75,13 @@ mod ffi {
             blockscout_base_url: String,
             account_address: String,
         ) -> Result<Vec<RawTokenResult>>;
+        pub fn get_token_transfers_blocking(
+            blockscout_base_url: String,
+            address: String,
+            contract_address: String,
+            option: QueryOption,
+        ) -> Result<Vec<RawTxDetail>>;
+
     }
 }
 
@@ -129,15 +138,88 @@ pub fn get_tokens_blocking(
 ) -> Result<Vec<RawTokenResult>> {
     let blockscout_url =
         format!("{blockscout_base_url}?module=account&action=tokenlist&address={account_address}");
-    let resp = reqwest::blocking::get(&blockscout_url)?.json::<RawTokenResponse>()?;
+    let resp = reqwest::blocking::get(&blockscout_url)?.json::<RawResponse<RawTokenResult>>()?;
     Ok(resp.result)
 }
 
+/// given the BlockScout REST API base url and the account address (hexadecimal; required)
+/// and optional contract address (hexadecimal; optional -- it can be empty if the option is ByAddress),
+/// it will return all the token transfers (ERC20, ERC721... in the newer BlockScout
+/// releases, also ERC1155)
+/// (ref: https://cronos.org/explorer/testnet3/api-docs)
+/// NOTE: QueryOption::ByContract is not supported by BlockScout
+pub fn get_token_transfers_blocking(
+    blockscout_base_url: String,
+    address: String,
+    contract_address: String,
+    option: QueryOption,
+) -> Result<Vec<RawTxDetail>> {
+    let blockscout_url = match option {
+        QueryOption::ByAddress => {
+            format!("{blockscout_base_url}?module=account&action=tokentx&address={address}")
+        }
+        QueryOption::ByAddressAndContract => {
+            format!(
+                "{blockscout_base_url}?module=account&action=tokentx&address={address}&contractaddress={contract_address}"
+            )
+        }
+        _ => {
+            anyhow::bail!("unsupported option")
+        }
+    };
+    let resp =
+        reqwest::blocking::get(&blockscout_url)?.json::<RawResponse<RawBlockScoutTransfer>>()?;
+
+    Ok(resp.result.iter().flat_map(TryInto::try_into).collect())
+}
+
 #[derive(Serialize, Deserialize)]
-struct RawTokenResponse {
+struct RawResponse<R> {
     message: String,
-    result: Vec<RawTokenResult>,
+    result: Vec<R>,
     status: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawBlockScoutTransfer {
+    block_hash: String,
+    block_number: String,
+    confirmations: String,
+    contract_address: String,
+    cumulative_gas_used: String,
+    from: String,
+    gas: String,
+    gas_price: String,
+    gas_used: String,
+    hash: String,
+    input: String,
+    log_index: String,
+    nonce: String,
+    time_stamp: String,
+    to: String,
+    token_decimal: String,
+    token_name: String,
+    token_symbol: String,
+    transaction_index: String,
+    value: String,
+}
+
+impl TryFrom<&RawBlockScoutTransfer> for RawTxDetail {
+    type Error = anyhow::Error;
+
+    fn try_from(tx: &RawBlockScoutTransfer) -> Result<Self, Self::Error> {
+        let block_no = tx.block_number.parse::<u64>()?;
+        Ok(Self {
+            hash: tx.hash.clone(),
+            to_address: tx.to.clone(),
+            from_address: tx.from.clone(),
+            value: tx.value.clone(),
+            block_no,
+            timestamp: tx.time_stamp.clone(),
+            contract_address: tx.contract_address.clone(),
+        })
+    }
 }
 
 impl From<&NormalTransaction> for RawTxDetail {
@@ -252,7 +334,7 @@ mod test {
     pub fn test_get_tokens() {
         let expected: Vec<RawTokenResult> = serde_json::from_str(r#"[{"balance":"36330128084034373866325","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2883410031878","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"161","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0x1e0edbea442cfeff05ed1b01f0c38ecb768de0e0","decimals":"","name":"NFT Gold","symbol":"Gold","type":"ERC-1155"},{"balance":"1","contractAddress":"0x93d0c9a35c43f6bc999416a06aadf21e68b29eba","decimals":"","name":"Unique One","symbol":"UNE","type":"ERC-1155"},{"balance":"1","contractAddress":"0x93d0c9a35c43f6bc999416a06aadf21e68b29eba","decimals":"","name":"Unique One","symbol":"UNE","type":"ERC-1155"},{"balance":"1","contractAddress":"0x57aaaf5a61b6a370f981b7826843694cfa4774e1","decimals":"","name":"Protector","symbol":"サイタマ","type":"ERC-1155"},{"balance":"1","contractAddress":"0x57aaaf5a61b6a370f981b7826843694cfa4774e1","decimals":"","name":"Protector","symbol":"サイタマ","type":"ERC-1155"},{"balance":"1","contractAddress":"0x57aaaf5a61b6a370f981b7826843694cfa4774e1","decimals":"","name":"Protector","symbol":"サイタマ","type":"ERC-1155"},{"balance":"4","contractAddress":"0x93d0c9a35c43f6bc999416a06aadf21e68b29eba","decimals":"","name":"Unique One","symbol":"UNE","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"2","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"5","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"4","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"9","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"4","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"9","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"9","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"1","contractAddress":"0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a","decimals":"","name":"SNAFU","symbol":"SNAFU","type":"ERC-1155"},{"balance":"36616853110389525899548","contractAddress":"0x27b9c2bd4baea18abdf49169054c1c1c12af9862","decimals":"18","name":"SNAFU","symbol":"SNAFU","type":"ERC-20"},{"balance":"73000000000000000000","contractAddress":"0x586f8a53c24d8d35a9f49e94d09058560791803e","decimals":"18","name":"NFTOPIUM","symbol":"NTP","type":"ERC-20"},{"balance":"763467280363239051","contractAddress":"0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1","decimals":"18","name":"Wrapped Ether on xDai","symbol":"WETH","type":"ERC-20"},{"balance":"1","contractAddress":"0x90fda259cfbdb74f1804e921f523e660bfbe698d","decimals":"","name":"Unique Pixie","symbol":"UPIXIE","type":"ERC-721"},{"balance":"3000000000000000000","contractAddress":"0x9c58bacc331c9aa871afd802db6379a98e80cedb","decimals":"18","name":"Gnosis Token on xDai","symbol":"GNO","type":"ERC-20"}]"#).expect("parse");
 
-        // blacksout somestimes workks, sometimes not
+        // blacksout somestimes works, sometimes not
         let max_count = 10;
         for _ in 0..max_count {
             let actual_result = get_tokens_blocking(
@@ -280,5 +362,67 @@ mod test {
             }
         } // end for for loop
         panic!("test_get_tokens failed");
+    }
+
+    #[test]
+    pub fn test_get_token_transactions() {
+        let expected: Vec<RawBlockScoutTransfer> = serde_json::from_str(
+            r#"[
+            {
+              "value": "200000000000000000000",
+              "blockHash": "0x1456b7934898b7c735967e849effc4dc45e84ff32c6c2e130d572cb9589ca652",
+              "blockNumber": "2088372",
+              "confirmations": "537920",
+              "contractAddress": "0x715b4d660148c477e03358f8b0315ed4088fe89a",
+              "cumulativeGasUsed": "31760308",
+              "from": "0x9ad08de843158b0a4f8efdae6ea49caf77bbf13f",
+              "gas": "145930",
+              "gasPrice": "2021527882398",
+              "gasUsed": "97287",
+              "hash": "0x0890c4dce61da8713db5844fa0ae0aa73b74ea6ccfa91c90065ae80471cd908c",
+              "input": "0x3363315c000000000000000000000000841a15d12aec9c6039fd132c2fbff112ed355700",
+              "logIndex": "104",
+              "nonce": "13",
+              "timeStamp": "1646318156",
+              "to": "0x841a15d12aec9c6039fd132c2fbff112ed355700",
+              "tokenDecimal": "18",
+              "tokenName": "DAI",
+              "tokenSymbol": "DAI",
+              "transactionIndex": "37"
+            },
+            {
+              "value": "200000000",
+              "blockHash": "0x307edc85e8d5bde617857831427cb90e0c9b2b6c455d6f3a56918c3ee4aa009d",
+              "blockNumber": "2039569",
+              "confirmations": "586723",
+              "contractAddress": "0xf0307093f23311fe6776a7742db619eb3df62969",
+              "cumulativeGasUsed": "97352",
+              "from": "0x9ad08de843158b0a4f8efdae6ea49caf77bbf13f",
+              "gas": "146028",
+              "gasPrice": "5017552095418",
+              "gasUsed": "97352",
+              "hash": "0x7939078155138ed15a10343627a4e6b8d623d63bdd69479bf62d7872dee587d6",
+              "input": "0xd8215830000000000000000000000000841a15d12aec9c6039fd132c2fbff112ed355700",
+              "logIndex": "0",
+              "nonce": "18",
+              "timeStamp": "1646036708",
+              "to": "0x841a15d12aec9c6039fd132c2fbff112ed355700",
+              "tokenDecimal": "6",
+              "tokenName": "USDC",
+              "tokenSymbol": "USDC",
+              "transactionIndex": "0"
+            }
+          ]"#,
+        )
+        .expect("parse");
+        let expected: Vec<RawTxDetail> = expected.iter().flat_map(TryInto::try_into).collect();
+        let actual = get_token_transfers_blocking(
+            "https://cronos.org/explorer/testnet3/api".to_string(),
+            "0x841a15D12aEc9c6039FD132c2FbFF112eD355700".to_string(),
+            "".to_string(),
+            QueryOption::ByAddress,
+        )
+        .expect("blockscout query");
+        assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
Solution: added bindings for BlockScout API
-- depending on the version of BlockScout, it may return ERC1155 transfer events as well.
(unlike Etherscan/Cronoscan, BlockScout has only a single method
for all token type history... i.e. one can use it for ERC20, ERC721
plus ERC1155 in newer versions)