### PR TITLE
Problem: cannot give c++ callback correctly (fix #90)

### DIFF
--- a/extra-cpp-bindings/include/walletconnectcallback.h
+++ b/extra-cpp-bindings/include/walletconnectcallback.h
@@ -49,10 +49,10 @@ class WalletConnectCallback {
     public:
     WalletConnectCallback();
     virtual ~WalletConnectCallback();
-    void onConnected(std::unique_ptr<WalletConnectSessionInfo> sessioninfo) const;
-    void onDisconnected(std::unique_ptr<WalletConnectSessionInfo> sessioninfo) const ;
-    void onConnecting(std::unique_ptr<WalletConnectSessionInfo> sessioninfo) const ;
-    void onUpdated(std::unique_ptr<WalletConnectSessionInfo> sessioninfo) const;
+    virtual void onConnected(std::unique_ptr<WalletConnectSessionInfo> sessioninfo) const;
+    virtual void onDisconnected(std::unique_ptr<WalletConnectSessionInfo> sessioninfo) const ;
+    virtual void onConnecting(std::unique_ptr<WalletConnectSessionInfo> sessioninfo) const ;
+    virtual void onUpdated(std::unique_ptr<WalletConnectSessionInfo> sessioninfo) const;
 };
 
 std::unique_ptr<WalletConnectCallback> new_walletconnect_callback();

--- a/extra-cpp-bindings/src/lib.rs
+++ b/extra-cpp-bindings/src/lib.rs
@@ -23,7 +23,6 @@ mod ffi {
 
         type WalletConnectCallback;
 
-        fn new_walletconnect_callback() -> UniquePtr<WalletConnectCallback>;
         fn onConnected(&self, sessioninfo: UniquePtr<WalletConnectSessionInfo>);
         fn onDisconnected(&self, sessioninfo: UniquePtr<WalletConnectSessionInfo>);
         fn onConnecting(&self, sessioninfo: UniquePtr<WalletConnectSessionInfo>);
@@ -155,7 +154,10 @@ mod ffi {
         ) -> Result<Box<WalletconnectClient>>;
 
         /// setup callback
-        pub fn setup_callback(&mut self) -> Result<()>;
+        pub fn setup_callback(
+            &mut self,
+            usercallback: UniquePtr<WalletConnectCallback>,
+        ) -> Result<()>;
         /// create or restore a session
         /// once session is created, it will be reused
         pub fn ensure_session_blocking(

--- a/extra-cpp-bindings/src/walletconnect.rs
+++ b/extra-cpp-bindings/src/walletconnect.rs
@@ -264,8 +264,8 @@ impl WalletconnectClient {
         Ok(result.to_vec())
     }
 
-    pub fn setup_callback(&mut self) -> Result<()> {
-        let cppcallback = crate::ffi::new_walletconnect_callback();
+    pub fn setup_callback(&mut self, usercallback: UniquePtr<WalletConnectCallback>) -> Result<()> {
+        let cppcallback = usercallback;
         if let Some(client) = self.client.as_mut() {
             let result = self
                 .rt

--- a/extra-cpp-bindings/src/walletconnectcallback.cc
+++ b/extra-cpp-bindings/src/walletconnectcallback.cc
@@ -101,9 +101,6 @@ void WalletConnectCallback::onUpdated(std::unique_ptr<WalletConnectSessionInfo> 
   print_session(sessioninfo);
 }
 
-std::unique_ptr<WalletConnectCallback> new_walletconnect_callback() {
-  return std::make_unique<WalletConnectCallback>();
-}
 
 } // namespace game_sdk
 } // namespace crypto


### PR DESCRIPTION
Solution: make c++ can give callback to rust using unique_ptr & move
previously, it's hard-coded inside library, couldn't change in c++ side
with `std::move`, ownership transferred to rust side
