### PR TITLE
Problem: upgrading ethers to 0.17 fails (fixes #173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,8 +750,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb61f3d2224c90ea78e1fa7444787761a549170c46b6b0ed09b93f9b7e4076a"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "tendermint-proto",
  "tonic",
 ]
@@ -768,8 +768,8 @@ dependencies = [
  "eyre",
  "getrandom 0.2.7",
  "k256",
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "rand_core 0.6.3",
  "serde",
  "serde_json",
@@ -1027,7 +1027,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "once_cell",
- "prost",
+ "prost 0.10.4",
  "rand 0.6.5",
  "rand 0.7.3",
  "rand_core 0.6.3",
@@ -1073,8 +1073,8 @@ version = "0.1.0"
 dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.11.1",
  "serde",
  "tendermint-proto",
  "tonic",
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198a76d7ff7be414df68692a8f5bb86ec2698aa58bab5092ab89e37334064442"
+checksum = "16142eeb3155cfa5aec6be3f828a28513a28bd995534f945fa70e7d608f16c10"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1342,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7e8db5a961eacf62c5ca68a3ddbee066f91717b826e2da0ed5bfed5b92d795"
+checksum = "e23f8992ecf45ea9dd2983696aabc566c108723585f07f5dc8c9efb24e52d3db"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42af664b7ec2154ea6d8d393fb65e14e9e857039d0d96905acef196689063ffe"
+checksum = "2e0010fffc97c5abcf75a30fd75676b1ed917b2b82beb8270391333618e2847d"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1373,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ecf7d921039dfe65b1148e9b3687d2a877b0413c33bee3a432e5e2e5c65f86"
+checksum = "bda76ce804d524f693a898dc5857d08f4db443f3da64d0c36237fa05c0ecef30"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -1396,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c1e66c2c29037cea672b6552381f33486fd663ce3350653e6f8e6af150ef42"
+checksum = "41170ccb5950f559cba5a052158a28ec2d224af3a7d5b266b3278b929538ef55"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a95c6dbf3cf0cb6e595f9a250a8c4b3a14740bd374e93f9176e3bd5318620d"
+checksum = "0ebdd63c828f58aa067f40f9adcbea5e114fb1f90144b3a1e2858e0c9b1ff4e8"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1443,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ec38aae5f36aa433a9c532ec458f85141beff52965a2ab09fc3f77a47e091b"
+checksum = "b279a3d00bd219caa2f9a34451b4accbfa9a1eaafc26dcda9d572591528435f0"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.7",
@@ -1460,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27dc8ef6f63a3fe5021e8ca7a063fff5cf1faf954cf4296998ac78dad0bd5a30"
+checksum = "b1e7e8632d28175352b9454bbcb604643b6ca1de4d36dc99b3f86860d75c132b"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66c690ae7f12a5a53eb91a7de40564248b8cdb6141c1e4f860d12ed23be1250"
+checksum = "e46482e4d1e79b20c338fd9db9e166184eb387f0a4e7c05c5b5c0aa2e8c8900c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56536bcb4979e06a026a5edfd6bf8167368e23401e4c8a8a56345adb5ad91bd2"
+checksum = "73a72ecad124e8ccd18d6a43624208cab0199e59621b1f0fa6b776b2e0529107"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86afd894e3078fbb57c24ac2ab8ddb0feeaff867da310c2f1092650a306ef4d4"
+checksum = "ebe5db405d0e584aa8dae154ffebb90f2305cae588fd11d9f6b857ebe3a79294"
 dependencies = [
  "cfg-if",
  "colored",
@@ -1578,8 +1578,6 @@ dependencies = [
  "cxx-build",
  "defi-wallet-connect",
  "ethers",
- "ethers-core",
- "ethers-etherscan",
  "hex",
  "reqwest",
  "serde",
@@ -1616,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "fastrlp"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c60b758dc5bf92743e1b863ac88b84a4750bd096b19c2f524359659dc1f1ac"
+checksum = "089263294bb1c38ac73649a6ad563dd9a5142c8dc0482be15b8b9acb22a1611e"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -2077,8 +2075,8 @@ dependencies = [
  "ics23",
  "num-traits",
  "primitive-types",
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "safe-regex",
  "serde",
  "serde_derive",
@@ -2101,8 +2099,8 @@ checksum = "90a15705281fee331d23850158ced81d3c5fbea520a55ede431390564bb8bdcc"
 dependencies = [
  "base64 0.13.0",
  "bytes",
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "serde",
  "tendermint-proto",
 ]
@@ -2116,7 +2114,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "hex",
- "prost",
+ "prost 0.10.4",
  "ripemd160",
  "sha2 0.9.9",
  "sha3 0.9.1",
@@ -2901,9 +2899,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -2915,7 +2913,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.0",
 ]
 
 [[package]]
@@ -2932,13 +2940,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.10.4",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+dependencies = [
+ "bytes",
+ "prost 0.11.0",
 ]
 
 [[package]]
@@ -4007,8 +4038,8 @@ dependencies = [
  "k256",
  "num-traits",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "ripemd160",
  "serde",
  "serde_bytes",
@@ -4060,8 +4091,8 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -4300,8 +4331,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.10.4",
+ "prost-derive 0.10.1",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",

--- a/extra-cpp-bindings/Cargo.toml
+++ b/extra-cpp-bindings/Cargo.toml
@@ -10,8 +10,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 [dependencies]
 anyhow = "1"
 cxx = "1"
-ethers-core = { version = "0.15" }
-ethers-etherscan = { version = "0.15" }
+ethers = { version = "0.17", features = ["rustls"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = "1"
 serde_json = { version = "1", features = ["arbitrary_precision"] }
@@ -19,7 +18,6 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 defi-wallet-connect= { path="../wallet-connect" }
 url = { version = "2", features = ["serde"] }
-ethers = { version = "0.15", features = ["rustls"] }
 hex="0.4.3"
 
 [build-dependencies]

--- a/extra-cpp-bindings/src/lib.rs
+++ b/extra-cpp-bindings/src/lib.rs
@@ -5,8 +5,8 @@ mod pay;
 mod walletconnect;
 use anyhow::Result;
 
-use ethers_core::types::{BlockNumber, Chain};
-use ethers_etherscan::{
+use ethers::core::types::{BlockNumber, Chain};
+use ethers::etherscan::{
     account::{
         ERC20TokenTransferEvent, ERC721TokenTransferEvent, NormalTransaction, TokenQueryOption,
     },

--- a/extra-cpp-bindings/src/walletconnect.rs
+++ b/extra-cpp-bindings/src/walletconnect.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use defi_wallet_connect::session::SessionInfo;
 use defi_wallet_connect::ClientChannelMessageType;
 use defi_wallet_connect::{Client, Metadata, WCMiddleware};
-use ethers_core::types::transaction::eip2718::TypedTransaction;
+use ethers::core::types::transaction::eip2718::TypedTransaction;
 use url::Url;
 
 use crate::ffi::WalletConnectSessionInfo;

--- a/wallet-connect/Cargo.toml
+++ b/wallet-connect/Cargo.toml
@@ -8,7 +8,7 @@ aes = "0.8"
 async-trait = { version = "0.1", default-features = false }
 cbc = { version = "0.1", features = ["alloc"] }
 dashmap = "5"
-ethers = { version = "0.15", features = ["rustls"] }
+ethers = { version = "0.17", features = ["rustls"] }
 eyre = "0.6"
 futures = "0.3"
 hmac = "0.12"


### PR DESCRIPTION
Solution: migrated crates to use `ethers` instead of sub-crates
and bumped to 0.17
plus the latest defi-wallet-core
