### PR TITLE
Problem: defi-wallet-core not updated (fix #185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## [Unreleased]
 
 
+## [v0.0.4-alpha] - 2020-08-10
+Add get-backup-mnemonics, generate-mnemonics
+
 ## [v0.0.3-alpha] - 2020-08-01
 Mac release to support 10.15 
 Fix unicode decode error on windows 11

--- a/play-cpp-sdk/Cargo.toml
+++ b/play-cpp-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "play-cpp-sdk"
-version = "0.0.2-alpha"
+version = "0.0.4-alpha"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
update defi-wallet-core
- get-backup-mnemonics
- get-mnemonics