### PR TITLE
Problem: Clang 14 breaks unreal 4.27 build on linux (fix #306)

### DIFF
--- a/.github/workflows/linux-libc++-build.yml
+++ b/.github/workflows/linux-libc++-build.yml
@@ -19,12 +19,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install clang-10
+        run: sudo apt install clang-10 libc++-10-dev libc++abi-10-dev
+
       - name: Build play-cpp-sdk library
-        run: CXX=clang++-14 CXXFLAGS=-stdlib=libc++ cargo build --package play-cpp-sdk --release
+        run: CXX=clang++-10 CXXFLAGS=-stdlib=libc++ cargo build --package play-cpp-sdk --release
 
       - name: Build demo project
         working-directory: demo
-        run: make CXX=clang++-14
+        run: make CXX=clang++-10
       - name: Pack binaries and bindings
         run: |
           PLATFORM="$(uname -s)_x86_64"

--- a/.github/workflows/linux-libc++-build.yml
+++ b/.github/workflows/linux-libc++-build.yml
@@ -13,14 +13,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-
-      - name: Install clang-10
-        run: sudo apt-get install -y clang-10 libc++-10-dev libc++abi-10-dev
 
       - name: Build play-cpp-sdk library
         run: CXX=clang++-10 CXXFLAGS=-stdlib=libc++ cargo build --package play-cpp-sdk --release

--- a/.github/workflows/linux-libc++-build.yml
+++ b/.github/workflows/linux-libc++-build.yml
@@ -20,7 +20,7 @@ jobs:
           submodules: recursive
 
       - name: Install clang-10
-        run: sudo apt install clang-10 libc++-10-dev libc++abi-10-dev
+        run: sudo apt-get install -y clang-10 libc++-10-dev libc++abi-10-dev
 
       - name: Build play-cpp-sdk library
         run: CXX=clang++-10 CXXFLAGS=-stdlib=libc++ cargo build --package play-cpp-sdk --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   integration_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       WASM_BINDGEN_TEST_TIMEOUT: 60
     steps:
@@ -38,9 +38,6 @@ jobs:
           name: debug-files
           path: debug_files.tar.gz
           if-no-files-found: ignore
-
-      - name: Install clang-10
-        run: sudo apt-get install -y clang-10 libc++-10-dev libc++abi-10-dev
 
       - name: Build play-cpp-sdk library
         run: CXX=clang++-10 CXXFLAGS=-stdlib=libc++ cargo build --package play-cpp-sdk --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,15 @@ jobs:
           path: debug_files.tar.gz
           if-no-files-found: ignore
 
+      - name: Install clang-10
+        run: sudo apt install clang-10 libc++-10-dev libc++abi-10-dev
+
       - name: Build play-cpp-sdk library
-        run: CXX=clang++-14 CXXFLAGS=-stdlib=libc++ cargo build --package play-cpp-sdk --release
+        run: CXX=clang++-10 CXXFLAGS=-stdlib=libc++ cargo build --package play-cpp-sdk --release
 
       - name: Build demo project
         working-directory: demo
-        run: make CXX=clang++-14
+        run: make CXX=clang++-10
 
       - name: Run cpp tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Install clang-10
-        run: sudo apt install clang-10 libc++-10-dev libc++abi-10-dev
+        run: sudo apt-get install -y clang-10 libc++-10-dev libc++abi-10-dev
 
       - name: Build play-cpp-sdk library
         run: CXX=clang++-10 CXXFLAGS=-stdlib=libc++ cargo build --package play-cpp-sdk --release


### PR DESCRIPTION
Close:
- #306 

Solution:
- Use ubuntu 20.04 and clang-10 to build linux libc binary

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/play-cpp-sdk/blob/main/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest main? 
- [ ] Have you checked your code compiles? (`cargo build`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`cargo test`)
- [ ] Have you checked your code formatting is correct? (`cargo fmt -- --check --color=auto`)
- [ ] Have you checked your basic code style is fine? (`cargo clippy`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`cargo audit`)
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/play-cpp-sdk/blob/main/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/play-cpp-sdk/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/play-cpp-sdk/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Thank you for your code, it's appreciated! :)
