### PR TITLE
Problem: missing support of wallet connect 2.0 (fixes #350)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,8 @@ dependencies = [
  "hmac",
  "open",
  "qrcodegen",
+ "quickcheck",
+ "quickcheck_macros",
  "rand 0.8.5",
  "relay_client",
  "relay_rpc",
@@ -1542,6 +1544,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -3515,6 +3527,28 @@ name = "qrcodegen"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4339fc7a1021c9c1621d87f5e3505f2805c8c105420ba2f2a4df86814590c142"
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "quote"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array 0.14.6",
+]
+
+[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +57,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
@@ -674,6 +684,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.3",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher 0.4.3",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +737,7 @@ checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -764,7 +799,7 @@ dependencies = [
  "bs58",
  "coins-core",
  "digest 0.10.6",
- "getrandom",
+ "getrandom 0.2.8",
  "hmac",
  "k256",
  "lazy_static",
@@ -781,11 +816,11 @@ checksum = "2a11892bcac83b4c6e95ab84b5b06c76d9d70ad73548dd07418269c5c7977171"
 dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
- "getrandom",
+ "getrandom 0.2.8",
  "hex",
  "hmac",
  "pbkdf2",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.6",
  "thiserror",
 ]
@@ -905,7 +940,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "ecdsa",
  "eyre",
- "getrandom",
+ "getrandom 0.2.8",
  "k256",
  "rand_core 0.6.4",
  "serde",
@@ -1001,6 +1036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.6",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1011,6 +1047,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.3",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1119,24 +1168,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+
+[[package]]
 name = "defi-wallet-connect"
 version = "0.1.0"
 dependencies = [
  "aes 0.8.2",
  "anyhow",
  "async-trait",
+ "base64 0.21.0",
  "cbc",
+ "chacha20poly1305",
  "dashmap",
  "ethers",
  "eyre",
  "futures",
+ "hkdf",
  "hmac",
  "open",
  "qrcodegen",
- "rand",
+ "rand 0.8.5",
+ "relay_client",
+ "relay_rpc",
  "secrecy",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2 0.10.6",
  "subtle",
  "thiserror",
@@ -1145,6 +1206,7 @@ dependencies = [
  "url",
  "uuid 1.3.0",
  "ws_stream_wasm",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -1169,7 +1231,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "prost",
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",
  "reqwest",
@@ -1399,6 +1461,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=7529d65#7529d65506147b6cb24ca6d8f4fc062cac33b395"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,7 +1586,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2",
- "rand",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
@@ -1627,7 +1702,7 @@ dependencies = [
  "dunce",
  "ethers-core",
  "eyre",
- "getrandom",
+ "getrandom 0.2.8",
  "hex",
  "proc-macro2",
  "quote",
@@ -1675,7 +1750,7 @@ dependencies = [
  "once_cell",
  "open-fastrlp",
  "proc-macro2",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "rlp-derive",
  "serde",
@@ -1694,7 +1769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9713f525348e5dde025d09b0a4217429f8074e8ff22c886263cc191e87d8216"
 dependencies = [
  "ethers-core",
- "getrandom",
+ "getrandom 0.2.8",
  "reqwest",
  "semver",
  "serde",
@@ -1743,7 +1818,7 @@ dependencies = [
  "futures-core",
  "futures-timer",
  "futures-util",
- "getrandom",
+ "getrandom 0.2.8",
  "hashers",
  "hex",
  "http",
@@ -1779,7 +1854,7 @@ dependencies = [
  "eth-keystore",
  "ethers-core",
  "hex",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.6",
  "thiserror",
 ]
@@ -1793,7 +1868,7 @@ dependencies = [
  "cfg-if",
  "dunce",
  "ethers-core",
- "getrandom",
+ "getrandom 0.2.8",
  "glob",
  "hex",
  "home",
@@ -1889,7 +1964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2101,6 +2176,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
@@ -2108,7 +2194,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2746,7 +2832,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
 ]
 
@@ -3193,7 +3279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3293,6 +3379,17 @@ dependencies = [
  "log",
  "wepoll-ffi",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3442,13 +3539,36 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3469,11 +3589,29 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3513,7 +3651,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "redox_syscall",
  "thiserror",
 ]
@@ -3534,6 +3672,46 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "relay_client"
+version = "0.1.0"
+source = "git+https://github.com/crypto-com/WalletConnectRust?rev=e104f0e0e95d5f2d14de63d8a627d1ccde100eb8#e104f0e0e95d5f2d14de63d8a627d1ccde100eb8"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures-channel",
+ "futures-util",
+ "pin-project",
+ "relay_rpc",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.18.0",
+ "tokio-util",
+]
+
+[[package]]
+name = "relay_rpc"
+version = "0.1.0"
+source = "git+https://github.com/crypto-com/WalletConnectRust?rev=e104f0e0e95d5f2d14de63d8a627d1ccde100eb8#e104f0e0e95d5f2d14de63d8a627d1ccde100eb8"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek",
+ "once_cell",
+ "rand 0.7.3",
+ "regex",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "reqwest"
@@ -3873,7 +4051,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.6",
  "zbus",
@@ -3965,6 +4143,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -4121,7 +4310,7 @@ dependencies = [
  "http",
  "iri-string",
  "k256",
- "rand",
+ "rand 0.8.5",
  "sha3",
  "thiserror",
  "time",
@@ -4266,7 +4455,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "semver",
  "serde",
@@ -4412,7 +4601,7 @@ checksum = "991779ca9b697471df9d436489774d144a418c0e5da843c58ff9288105d5ddaa"
 dependencies = [
  "bytes",
  "flex-error",
- "getrandom",
+ "getrandom 0.2.8",
  "peg",
  "pin-project",
  "serde",
@@ -4725,7 +4914,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -4826,7 +5015,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "sha-1",
  "thiserror",
@@ -4847,7 +5036,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "sha1",
  "thiserror",
@@ -4930,6 +5119,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4959,7 +5158,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "serde",
 ]
 
@@ -4969,7 +5168,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "serde",
  "wasm-bindgen",
 ]
@@ -5006,6 +5205,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -5340,6 +5545,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
 name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5370,7 +5586,7 @@ dependencies = [
  "nix",
  "once_cell",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",

--- a/wallet-connect/Cargo.toml
+++ b/wallet-connect/Cargo.toml
@@ -33,6 +33,10 @@ url = { version = "2", features = ["serde"] }
 x25519-dalek = "1"
 zeroize = "1"
 
+[dev-dependencies]
+quickcheck = "1"
+quickcheck_macros = "1"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio-tungstenite = { version = "0.18", features = ["rustls-tls-native-roots"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/wallet-connect/Cargo.toml
+++ b/wallet-connect/Cargo.toml
@@ -8,22 +8,29 @@ license = "Apache-2.0"
 aes = "0.8"
 anyhow = "1"
 async-trait = { version = "0.1", default-features = false }
+base64 = "0.21"
+chacha20poly1305 = "0.10"
 cbc = { version = "0.1", features = ["alloc"] }
 dashmap = "5"
 ethers = { version = "1", features = ["rustls"] }
 eyre = "0.6"
 futures = "0.3"
+hkdf = "0.12"
 hmac = "0.12"
 open = "3"
 qrcodegen = "1"
 rand = "0.8"
+relay_client = { git = "https://github.com/crypto-com/WalletConnectRust", rev = "e104f0e0e95d5f2d14de63d8a627d1ccde100eb8"}
+relay_rpc = { git = "https://github.com/crypto-com/WalletConnectRust", rev = "e104f0e0e95d5f2d14de63d8a627d1ccde100eb8"}
 secrecy = "0.8"
 serde = "1"
 serde_json = "1"
+serde_with = "2"
 sha2 = "0.10"
 subtle = "2"
 thiserror = "1"
 url = { version = "2", features = ["serde"] }
+x25519-dalek = "1"
 zeroize = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -37,3 +44,6 @@ ws_stream_wasm = { version = "0.7" }
 
 [[example]]
 name = "web3"
+
+[[example]]
+name = "web3_v2"

--- a/wallet-connect/examples/web3_v2.rs
+++ b/wallet-connect/examples/web3_v2.rs
@@ -1,0 +1,43 @@
+use std::error::Error;
+
+use defi_wallet_connect::v2::{Client, ClientOptions, Metadata, RequiredNamespaces};
+
+async fn make_client() -> Result<Client, relay_client::Error> {
+    let opts = ClientOptions {
+        relay_server: "wss://relay.walletconnect.com".parse().expect("url"),
+        project_id: std::env::args().skip(1).next().expect("project_id"),
+        required_namespaces: RequiredNamespaces::new(
+            vec![
+                "eth_sendTransaction".to_owned(),
+                "eth_signTransaction".to_owned(),
+                "eth_sign".to_owned(),
+                "personal_sign".to_owned(),
+                "eth_signTypedData".to_owned(),
+            ],
+            vec!["eip155:5".to_owned()],
+            vec!["chainChanged".to_owned(), "accountsChanged".to_owned()],
+        ),
+        client_meta: Metadata {
+            description: "Defi WalletConnect v2 example.".into(),
+            url: "http://localhost:8080/".parse().expect("url"),
+            icons: vec![],
+            name: "Defi WalletConnect Web3 Example".into(),
+        },
+    };
+
+    Client::new(opts).await
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // TODO: qrcode display
+    let mut client = make_client().await?;
+    let uri = client.get_connection_string().await;
+    println!("connection string = {}", uri);
+    let namespaces = client.ensure_session().await?;
+    println!("namespaces = {:?}", namespaces);
+    let address1 = namespaces.get_ethereum_addresses()[0].address;
+    let sig1 = client.personal_sign("Hello Crypto", &address1).await?;
+    println!("sig1: {:?}", sig1);
+    Ok(())
+}

--- a/wallet-connect/src/lib.rs
+++ b/wallet-connect/src/lib.rs
@@ -10,6 +10,6 @@ mod protocol;
 mod serialization;
 /// utilities for the connection URI: https://docs.walletconnect.com/tech-spec#requesting-connection
 mod uri;
-
+pub mod v2;
 pub use client::*;
 pub use protocol::*;

--- a/wallet-connect/src/protocol/rpc.rs
+++ b/wallet-connect/src/protocol/rpc.rs
@@ -90,11 +90,11 @@ fn is_zst<T>(_t: &T) -> bool {
 /// A JSON-RPC request
 /// (taken from ethers as it's not exported)
 pub struct Request<'a, T> {
-    id: u64,
+    pub id: u64,
     jsonrpc: &'a str,
     method: &'a str,
     #[serde(skip_serializing_if = "is_zst")]
-    params: T,
+    pub params: T,
 }
 
 impl<'a, T> Request<'a, T> {
@@ -154,6 +154,16 @@ pub struct Response<T> {
     /// the result of the request
     #[serde(flatten)]
     pub data: ResponseData<T>,
+}
+
+impl<T> Response<T> {
+    pub fn new(id: u64, result: T) -> Self {
+        Self {
+            id,
+            jsonrpc: "2.0".into(),
+            data: ResponseData::Success { result },
+        }
+    }
 }
 
 /// the result of the request

--- a/wallet-connect/src/v2/client.rs
+++ b/wallet-connect/src/v2/client.rs
@@ -1,0 +1,241 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use ethers::types::transaction::eip2718::TypedTransaction;
+use ethers::{
+    prelude::{
+        Address, Bytes, FromErr, JsonRpcClient, Middleware, NameOrAddress, Provider, Signature,
+        TransactionRequest,
+    },
+    utils::rlp,
+};
+use eyre::eyre;
+use eyre::Context;
+use serde::{de::DeserializeOwned, Serialize};
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::RwLock;
+use url::Url;
+
+use crate::{hex, ClientError};
+
+use super::core::Connector;
+use super::protocol::{Namespaces, RequiredNamespaces};
+use super::session::SessionInfo;
+use super::Metadata;
+use relay_client::Error;
+
+/// The WalletConnect 2.0 basic client options
+pub struct ClientOptions {
+    /// The relay server url
+    /// (the default is wss://relay.walletconnect.org)
+    /// Note that `Url` will append `/` and
+    /// the current relay_client implementation
+    /// would return 404 in that case, so make sure
+    /// to pop off the trailing `/`
+    pub relay_server: Url,
+    /// The project id (obtained from the walletconnect.org registration)
+    pub project_id: String,
+    /// The required namespaces
+    /// (methods, chains, events) by the dApp
+    /// -- the wallet may not support them though
+    pub required_namespaces: RequiredNamespaces,
+    /// The client / dApp metadata
+    pub client_meta: Metadata,
+}
+
+/// The WalletConnect 2.0 client
+/// (holds the middleware trait implementations for ethers)
+/// this is persistent and can be recovered from session-info-string.
+/// session-info-string can be saved to the disk
+#[derive(Debug, Clone)]
+pub struct Client {
+    connection: Arc<RwLock<Connector>>, // Client is cloneable
+}
+
+impl Client {
+    /// Creates a new client from the provided metadata
+    pub async fn new(opts: ClientOptions) -> Result<Self, Error> {
+        let session = SessionInfo::new(
+            opts.relay_server,
+            opts.project_id,
+            opts.required_namespaces,
+            opts.client_meta,
+        );
+        let connector = Connector::new_client(session).await?;
+        Ok(Client {
+            connection: Arc::new(RwLock::new(connector)),
+        })
+    }
+
+    /// get current session info, can be saved , and later, restored
+    pub async fn get_session_info(&self) -> SessionInfo {
+        let connection = self.connection.read().await;
+        connection.get_session_info().await
+    }
+
+    /// create qrcode from this string
+    pub async fn get_connection_string(&self) -> String {
+        let connection = self.connection.read().await;
+        connection.get_uri().await
+    }
+
+    /// This will return an existing session or create a new session.
+    /// If successful, the returned value is the wallet's addresses and the chain ID.
+    /// TODO: more specific error types than eyre
+    pub async fn ensure_session(&mut self) -> Result<Namespaces, eyre::Error> {
+        let mut connection = self.connection.write().await;
+
+        connection.ensure_session().await?;
+        connection
+            .get_session_info()
+            .await
+            .namespaces
+            .ok_or_else(|| eyre!("No namespaces in session info"))
+    }
+
+    /// Send a request to sign a message as per https://eips.ethereum.org/EIPS/eip-1271
+    pub async fn personal_sign(
+        &mut self,
+        message: &str,
+        address: &Address,
+    ) -> Result<Signature, ClientError> {
+        let sig_str: String = self
+            .request(
+                "personal_sign",
+                vec![
+                    format!("0x{}", hex::encode(message)),
+                    format!("{address:?}"),
+                    // "".to_string(), // TODO is password needed?
+                ],
+            )
+            .await?;
+
+        Signature::from_str(&sig_str)
+            .context("failed to parse signature")
+            .map_err(ClientError::Eyre)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl JsonRpcClient for Client {
+    type Error = ClientError;
+
+    /// Sends a POST request with the provided method and the params serialized as JSON
+    /// over HTTP
+    async fn request<T: Serialize + Send + Sync + std::fmt::Debug, R: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: T,
+    ) -> Result<R, ClientError> {
+        let connection = self.connection.read().await;
+        connection.request(method, params).await
+    }
+}
+
+/// The wrapper struct for `ethers` middleware
+/// TODO: override transaction-related middleware methods,
+/// so that the client broadcasts the transaction (instead of the wallet)?
+#[derive(Debug)]
+pub struct WCMiddleware<M>(M);
+
+impl WCMiddleware<Provider<Client>> {
+    /// Creates a new wrapper for `ethers` middleware
+    pub fn new(client: Client) -> Self {
+        WCMiddleware(Provider::new(client))
+    }
+}
+
+/// The wrapper error type for `ethers` middleware-related issues
+#[derive(Error, Debug)]
+pub enum WCError<M: Middleware> {
+    #[error("{0}")]
+    MiddlewareError(M::Error),
+    #[error("client error: {0}")]
+    ClientError(ClientError),
+}
+
+impl<M: Middleware> FromErr<M::Error> for WCError<M> {
+    fn from(src: M::Error) -> WCError<M> {
+        WCError::MiddlewareError(src)
+    }
+}
+
+#[async_trait]
+impl Middleware for WCMiddleware<Provider<Client>> {
+    type Error = WCError<Provider<Client>>;
+    type Provider = Client;
+    type Inner = Provider<Client>;
+
+    fn inner(&self) -> &Provider<Client> {
+        &self.0
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &TypedTransaction,
+        from: Address,
+    ) -> Result<Signature, Self::Error> {
+        let mut tx_obj = HashMap::new();
+        tx_obj.insert("from", format!("{from:?}"));
+        if let Some(to) = tx.to() {
+            let addr = match to {
+                NameOrAddress::Address(addr) => *addr,
+                NameOrAddress::Name(n) => self.resolve_name(n).await?,
+            };
+            tx_obj.insert("to", format!("{addr:?}"));
+        }
+        if let Some(data) = tx.data() {
+            tx_obj.insert("data", format!("0x{}", hex::encode(data)));
+        } else {
+            tx_obj.insert("data", "".to_string());
+        }
+        if let Some(gas) = tx.gas() {
+            tx_obj.insert("gas", format!("0x{gas:x}"));
+        }
+        if let Some(gas_price) = tx.gas_price() {
+            tx_obj.insert("gasPrice", format!("0x{gas_price:x}"));
+        }
+        if let Some(value) = tx.value() {
+            tx_obj.insert("value", format!("0x{value:x}"));
+        }
+        if let Some(nonce) = tx.nonce() {
+            tx_obj.insert("nonce", format!("0x{nonce:x}"));
+        }
+        if let Some(c) = tx.chain_id() {
+            tx_obj.insert("chainId", format!("0x{c:x}"));
+        }
+        // TODO: put those error cases to WCError instead of wrapping in eyre
+        let tx_bytes: Bytes = self
+            .0
+            .request("eth_signTransaction", vec![tx_obj])
+            .await
+            .map_err(|e| WCError::ClientError(ClientError::Eyre(eyre!(e))))?;
+        let tx_rlp = rlp::Rlp::new(tx_bytes.as_ref());
+        if tx_rlp.as_raw().is_empty() {
+            return Err(WCError::ClientError(ClientError::Eyre(eyre!(
+                "failed to decode transaction , empty rlp"
+            ))));
+        }
+
+        let first_byte = tx_rlp.as_raw()[0];
+        // TODO: check that the decoded request matches the typed transaction content here? or a new `sign_transaction` function that returns both request+signature?
+        if first_byte <= 0x7f {
+            let decoded_request = TypedTransaction::decode_signed(&tx_rlp);
+            decoded_request
+                .map(|x| x.1)
+                .map_err(|e| WCError::ClientError(ClientError::Eyre(eyre!(e))))
+        } else if (0xc0..=0xfe).contains(&first_byte) {
+            let decoded_request = TransactionRequest::decode_signed_rlp(&tx_rlp);
+            decoded_request
+                .map(|x| x.1)
+                .map_err(|e| WCError::ClientError(ClientError::Eyre(eyre!(e))))
+        } else {
+            Err(WCError::ClientError(ClientError::Eyre(eyre!(
+                "failed to decode transaction"
+            ))))
+        }
+    }
+}

--- a/wallet-connect/src/v2/core.rs
+++ b/wallet-connect/src/v2/core.rs
@@ -1,0 +1,388 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use ethers::providers::JsonRpcClient;
+use relay_client::{
+    Client, CloseFrame, ConnectionHandler, ConnectionOptions, Error, PublishedMessage,
+};
+use relay_rpc::{
+    auth::{ed25519_dalek::Keypair, rand, rand::Rng, AuthToken},
+    domain::{AuthSubject, SubscriptionId, Topic},
+};
+use serde::{de::DeserializeOwned, Serialize};
+use tokio::sync::{mpsc, oneshot, Mutex, Notify};
+
+use crate::{ClientError, Request, Response};
+
+use super::{
+    crypto::{decode_decrypt, encrypt_and_encode},
+    protocol::{
+        WcSessionProposeResponse, WcSessionRequest, WcSessionSettle,
+        WC_SESSION_PROPOSE_REQUEST_METHOD, WC_SESSION_PROPOSE_REQUEST_TAG,
+        WC_SESSION_REQUEST_METHOD, WC_SESSION_REQUEST_TAG, WC_SESSION_SETTLE_RESPONSE_TAG,
+    },
+    session::SessionInfo,
+};
+
+/// This `Context` holds the wallet-connect client state
+#[derive(Debug)]
+pub struct Context {
+    /// the current session information
+    /// it's under mutex, as it's accessed by multiple threads
+    /// and may be updated from the connected wallet
+    /// (e.g. when a new address is added)
+    pub session: Mutex<SessionInfo>,
+    /// will notify when the session is established
+    /// (after receiving the `wc_sessionSettle` request)
+    pub session_pending_notify: Notify,
+    /// record the time of the request and have a regular cleanup
+    pub pending_requests_timeout: Duration,
+    /// limit pending requests size
+    pub pending_requests_limit: usize,
+    /// the map of the requests that were sent to the wallet
+    /// and the client app is awaiting a response.
+    /// When the response is received, the request is removed
+    /// and the response is sent to the receiver via the one-shot channel.
+    pub pending_requests: DashMap<u64, oneshot::Sender<serde_json::Value>>,
+    /// the map of existing subscriptions
+    /// (currently unused; but may be used for deleting subscriptions etc.)
+    pub subscriptions: DashMap<Topic, SubscriptionId>,
+}
+
+/// `SharedContext` holds the thread-safe reference to the wallet-connect client state
+pub type SharedContext = Arc<Context>;
+
+impl Context {
+    /// Creates a new client state context from the provided session
+    /// (empty pending requests)
+    pub fn new(session: SessionInfo) -> Self {
+        Self {
+            session: Mutex::new(session),
+            session_pending_notify: Notify::new(),
+            pending_requests_timeout: Duration::from_millis(60000),
+            pending_requests_limit: 2,
+            pending_requests: DashMap::new(),
+            subscriptions: DashMap::new(),
+        }
+    }
+}
+
+/// The handler of WC 2.0 messages
+struct MessageHandler {
+    /// the shared context of the client
+    context: SharedContext,
+    /// if websocket is connected
+    /// (currently not used; for debugging purposes)
+    connected: bool,
+    /// the last error if any
+    /// (currently not used; for debugging purposes)
+    last_connection_error: Option<Error>,
+    sender: mpsc::Sender<ConnectorMessage>,
+}
+
+impl MessageHandler {
+    fn new(context: SharedContext, sender: mpsc::Sender<ConnectorMessage>) -> Self {
+        Self {
+            context,
+            connected: false,
+            last_connection_error: None,
+            sender,
+        }
+    }
+}
+
+#[async_trait]
+impl ConnectionHandler for MessageHandler {
+    async fn connected(&mut self) {
+        self.connected = true;
+    }
+
+    async fn disconnected(&mut self, _frame: Option<CloseFrame<'static>>) {
+        self.connected = false;
+    }
+
+    async fn message_received(&mut self, message: PublishedMessage) {
+        let mut session = self.context.session.lock().await;
+        match (&message.topic, &session.pairing_topic_symkey) {
+            // this case is for the session proposal
+            // so expecting the session proposal response there
+            (t, _) if t == &session.session_proposal_topic => {
+                if let Ok(plain) =
+                    decode_decrypt(&session.session_proposal_symkey, &message.message)
+                {
+                    if let Ok(response) =
+                        serde_json::from_slice::<Response<WcSessionProposeResponse>>(&plain)
+                    {
+                        if let Ok(r) = response.data.into_result() {
+                            // derive the new topic and symkey
+                            if let Some(t) = session.session_proposal_response(&r) {
+                                // subscribe to the new topic
+                                let _ = self
+                                    .sender
+                                    .send(ConnectorMessage::Subscribe(t.clone()))
+                                    .await;
+                            }
+                        }
+                        if let Some((_, sender)) =
+                            self.context.pending_requests.remove(&response.id)
+                        {
+                            // notify the client app that the session is being established
+                            let _ = sender.send(serde_json::Value::Null);
+                        }
+                    }
+                }
+            }
+            // this case is for the session settlement and normal requests
+            // (and events? TODO: check if session updates are sent here)
+            (t1, Some((t2, key))) if t1 == t2 => {
+                if let Ok(plain) = decode_decrypt(&key, &message.message) {
+                    // the response to normal RPC requests (e.g. eth_sendTransaction)
+                    if let Ok(response) =
+                        serde_json::from_slice::<Response<serde_json::Value>>(&plain)
+                    {
+                        if let Some((_, sender)) =
+                            self.context.pending_requests.remove(&response.id)
+                        {
+                            if let Ok(value) = response.data.into_value() {
+                                // notify the client dApp that the response is received
+                                let _ = sender.send(value);
+                            }
+                        }
+                    } else {
+                        // the request for session settlement
+                        if let Ok(request) =
+                            serde_json::from_slice::<Request<WcSessionSettle>>(&plain)
+                        {
+                            let response = Response::new(request.id, true);
+                            let response_str =
+                                serde_json::to_string(&response).expect("serialize response");
+                            let message = encrypt_and_encode(&key, response_str.as_bytes());
+                            // need to send a reply to the wallet
+                            let _ = self
+                                .sender
+                                .send(ConnectorMessage::Publish(
+                                    t1.clone(),
+                                    message,
+                                    WC_SESSION_SETTLE_RESPONSE_TAG,
+                                ))
+                                .await;
+                            session.session_settle(request.params);
+                            session.connected = true;
+                            // notify the client dApp that the session is settled
+                            self.context.session_pending_notify.notify_waiters();
+                        }
+                    }
+                }
+            }
+            _ => {
+                // unknown topic
+                // TODO: send back error?
+            }
+        }
+    }
+
+    async fn inbound_error(&mut self, error: Error) {
+        self.last_connection_error = Some(error);
+    }
+
+    async fn outbound_error(&mut self, error: Error) {
+        self.last_connection_error = Some(error);
+    }
+}
+
+/// maximum is 9007199254740991 , 2^53 -1
+/// cannot be zero
+fn get_safe_random() -> u64 {
+    let random_request_id: u64 = rand::thread_rng().gen();
+    random_request_id % 9007199254740990 + 1
+}
+
+/// Handles publishing messages and subscribing to topics
+#[derive(Debug)]
+pub struct Connector {
+    context: SharedContext,
+    _task_handler: tokio::task::JoinHandle<()>,
+    sender: mpsc::Sender<ConnectorMessage>,
+}
+
+/// messages processed in the task loop
+#[derive(Debug)]
+enum ConnectorMessage {
+    Publish(Topic, String, u32),
+    Subscribe(Topic),
+}
+
+impl Connector {
+    ///  create qrcode with this uri
+    pub async fn get_uri(&self) -> String {
+        let session = self.context.session.lock().await;
+        session.uri()
+    }
+
+    /// get session info, can be saved for restoration
+    pub async fn get_session_info(&self) -> SessionInfo {
+        let session = self.context.session.lock().await;
+        session.clone()
+    }
+
+    /// establishes the session
+    pub async fn ensure_session(&mut self) -> eyre::Result<()> {
+        // the session proposal topic
+        let topic = self
+            .context
+            .session
+            .lock()
+            .await
+            .session_proposal_topic
+            .clone();
+        use eyre::Context;
+        // subscribe to that topic
+        self.sender
+            .send(ConnectorMessage::Subscribe(topic.clone()))
+            .await
+            .wrap_err("subscribe")?;
+        // create a session proposal request
+        let session_request_id = get_safe_random();
+        let session = self.context.session.lock().await;
+        let session_request = Request::new(
+            session_request_id,
+            WC_SESSION_PROPOSE_REQUEST_METHOD,
+            session.session_proposal(),
+        );
+        let session_request_str =
+            serde_json::to_string(&session_request).expect("serialize session request");
+        let message = encrypt_and_encode(
+            &session.session_proposal_symkey,
+            session_request_str.as_bytes(),
+        );
+        // release the lock
+        drop(session);
+        let (proposal_sender, proposal_receiver) = oneshot::channel();
+        self.context
+            .pending_requests
+            .insert(session_request_id, proposal_sender);
+        // request for publishing the session proposal request
+        self.sender
+            .send(ConnectorMessage::Publish(
+                topic,
+                message,
+                WC_SESSION_PROPOSE_REQUEST_TAG,
+            ))
+            .await
+            .wrap_err("publish")?;
+        // wait for the session proposal response
+        let _ = proposal_receiver.await;
+        // wait for the session settle request
+        self.context.session_pending_notify.notified().await;
+        Ok(())
+    }
+
+    /// creates a new connector
+    pub async fn new_client(session: SessionInfo) -> Result<Self, Error> {
+        let mut relay_address = session.relay_server.clone().to_string();
+        // remove "/"
+        relay_address.pop();
+        let project_id = session.project_id.clone();
+        let context = Arc::new(Context::new(session));
+        let (sender, mut receiver) = mpsc::channel(10);
+        let handler = MessageHandler::new(context.clone(), sender.clone());
+        let client = Client::new(handler);
+        let key = Keypair::generate(&mut rand::thread_rng());
+        let auth = AuthToken::new(AuthSubject::generate())
+            .aud(relay_address.clone())
+            .ttl(Duration::from_secs(60 * 60))
+            .as_jwt(&key)
+            .expect("jwt token");
+        let opts = ConnectionOptions::new(project_id, auth).with_address(relay_address);
+        client.connect(opts).await?;
+
+        let task_context = context.clone();
+        // a task loop to handle messages
+        // that we need to send to the walletconnect relay server
+        let _task_handler = tokio::spawn(async move {
+            loop {
+                match receiver.recv().await {
+                    Some(ConnectorMessage::Publish(topic, message, tag)) => {
+                        let _ = client
+                            .publish(topic, message, tag, task_context.pending_requests_timeout)
+                            .await;
+                    }
+                    Some(ConnectorMessage::Subscribe(topic)) => {
+                        let sid = client.subscribe(topic.clone()).await;
+                        if let Ok(id) = sid {
+                            task_context.subscriptions.insert(topic, id);
+                        }
+                    }
+                    None => {
+                        break;
+                    }
+                }
+            }
+        });
+        Ok(Self {
+            context,
+            _task_handler,
+            sender,
+        })
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl JsonRpcClient for Connector {
+    type Error = ClientError;
+
+    /// Sends a POST request with the provided method and the params serialized as JSON
+    /// over HTTP
+    async fn request<T: Serialize + Send + Sync, R: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: T,
+    ) -> Result<R, ClientError> {
+        let session = self.context.session.lock().await;
+        let topickey = if let Some((topic, key)) = session.pairing_topic_symkey.as_ref() {
+            Some((topic.clone(), key.clone()))
+        } else {
+            None
+        };
+        // get chain id or default (cronos mainnet)
+        let chain_id = session
+            .required_namespaces
+            .eip155
+            .chains
+            .get(0)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| "eip155:25".to_owned());
+        // release the lock
+        drop(session);
+        // if pairing was established, we should have a topic + symmetric key
+        if let Some((topic, key)) = topickey {
+            let request_id = get_safe_random();
+            let params = WcSessionRequest::new(method.to_string(), params, chain_id);
+            let req = Request::new(request_id, WC_SESSION_REQUEST_METHOD, params);
+            use eyre::Context;
+            let request_str = serde_json::to_string(&req).wrap_err("serialize request")?;
+            let message = encrypt_and_encode(&key, request_str.as_bytes());
+            let (sender, receiver) = oneshot::channel();
+            self.context.pending_requests.insert(request_id, sender);
+            self.sender
+                .send(ConnectorMessage::Publish(
+                    topic.clone(),
+                    message,
+                    WC_SESSION_REQUEST_TAG,
+                ))
+                .await
+                .map_err(|e| ClientError::Eyre(eyre::eyre!(e)))?;
+            let response = receiver
+                .await
+                .map_err(|e| ClientError::Eyre(eyre::eyre!(e)))?;
+            let resp: R = serde_json::from_value(response).wrap_err("failed to parse response")?;
+            Ok(resp)
+        } else {
+            Err(ClientError::Eyre(eyre::eyre!(
+                "no pairing topic and symkey"
+            )))
+        }
+    }
+}

--- a/wallet-connect/src/v2/core.rs
+++ b/wallet-connect/src/v2/core.rs
@@ -136,7 +136,7 @@ impl ConnectionHandler for MessageHandler {
             // this case is for the session settlement and normal requests
             // (and events? TODO: check if session updates are sent here)
             (t1, Some((t2, key))) if t1 == t2 => {
-                if let Ok(plain) = decode_decrypt(&key, &message.message) {
+                if let Ok(plain) = decode_decrypt(key, &message.message) {
                     // the response to normal RPC requests (e.g. eth_sendTransaction)
                     if let Ok(response) =
                         serde_json::from_slice::<Response<serde_json::Value>>(&plain)
@@ -157,7 +157,7 @@ impl ConnectionHandler for MessageHandler {
                             let response = Response::new(request.id, true);
                             let response_str =
                                 serde_json::to_string(&response).expect("serialize response");
-                            let message = encrypt_and_encode(&key, response_str.as_bytes());
+                            let message = encrypt_and_encode(key, response_str.as_bytes());
                             // need to send a reply to the wallet
                             let _ = self
                                 .sender

--- a/wallet-connect/src/v2/crypto.rs
+++ b/wallet-connect/src/v2/crypto.rs
@@ -1,0 +1,66 @@
+use base64::{engine::general_purpose, Engine as _};
+use chacha20poly1305::{
+    aead::{Aead, KeyInit, OsRng},
+    AeadCore, ChaCha20Poly1305, Nonce,
+};
+use hkdf::Hkdf;
+use relay_rpc::domain::Topic;
+use sha2::{Digest, Sha256};
+use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::Zeroize;
+
+use crate::{crypto::Key, hex};
+
+/// After the session proposal response, we obtain the wallet's public key
+/// and derive a new topic and symmetric key for the pairing topic
+pub fn derive_symkey_topic(responder_public_key: &str, secret: &Key) -> Option<(Topic, Key)> {
+    let mut secret_buf = [0u8; 32];
+    secret_buf.copy_from_slice(&secret.as_ref());
+    let mut client_secret = StaticSecret::from(secret_buf);
+    match hex::decode(responder_public_key) {
+        Ok(pk) if pk.len() == 32 => {
+            let mut pk_b = [0u8; 32];
+            pk_b.copy_from_slice(&pk);
+            let responder_public = PublicKey::from(pk_b);
+            let shared_secret = client_secret.diffie_hellman(&responder_public);
+            let hkdf = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
+            let mut sym_key = [0u8; 32];
+
+            hkdf.expand(&[], &mut sym_key).expect("expand sym key");
+
+            let hashed = Sha256::digest(&sym_key[..]);
+            let new_topic = Topic::from(hex::encode(hashed));
+            secret_buf.zeroize();
+            client_secret.zeroize();
+            Some((new_topic, Key::from_raw(sym_key)))
+        }
+        _ => {
+            secret_buf.zeroize();
+            client_secret.zeroize();
+            None
+        }
+    }
+}
+
+/// Encrypt using ChaCha20Poly1305 and encode using base64
+/// The first byte is a version byte, the next 12 bytes are the nonce
+/// (see https://docs.walletconnect.com/2.0/specs/clients/core/crypto/crypto-envelopes#type-0-envelope)
+pub fn encrypt_and_encode(key: &Key, data: &[u8]) -> String {
+    let cipher = ChaCha20Poly1305::new_from_slice(key.as_ref()).expect("correct key");
+    let nonce = ChaCha20Poly1305::generate_nonce(OsRng {});
+    let ciphertext = cipher.encrypt(&nonce, data).expect("encryption");
+    let mut buf = vec![0];
+    buf.extend_from_slice(&nonce);
+    buf.extend_from_slice(&ciphertext);
+    general_purpose::STANDARD.encode(buf)
+}
+
+/// Decode using base64 and decrypt using ChaCha20Poly1305
+/// The first byte is a version byte, the next 12 bytes are the nonce
+/// (see https://docs.walletconnect.com/2.0/specs/clients/core/crypto/crypto-envelopes#type-0-envelope)
+pub fn decode_decrypt(key: &Key, data: &str) -> Result<Vec<u8>, ()> {
+    let decoded = general_purpose::STANDARD.decode(data).map_err(|_| ())?;
+    let cipher = ChaCha20Poly1305::new_from_slice(key.as_ref()).expect("correct key");
+    let nonce = Nonce::clone_from_slice(&decoded[1..13]);
+    cipher.decrypt(&nonce, &decoded[13..]).map_err(|_| ())
+}

--- a/wallet-connect/src/v2/mod.rs
+++ b/wallet-connect/src/v2/mod.rs
@@ -1,0 +1,8 @@
+mod client;
+mod core;
+mod crypto;
+mod protocol;
+mod session;
+
+pub use client::*;
+pub use protocol::*;

--- a/wallet-connect/src/v2/protocol.rs
+++ b/wallet-connect/src/v2/protocol.rs
@@ -1,0 +1,218 @@
+use std::{fmt::Display, str::FromStr};
+
+use ethers::types::Address;
+///! https://docs.walletconnect.com/2.0/specs/clients/sign/rpc-methods
+///! FIXME: wc_sessionUpdate
+///! FIXME: wc_sessionExtend
+///! FIXME: wc_sessionEvent
+///! FIXME: wc_sessionDelete
+///! FIXME: wc_sessionPing
+use serde::{Deserialize, Serialize};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+/// https://docs.walletconnect.com/2.0/specs/clients/sign/rpc-methods#wc_sessionpropose
+pub const WC_SESSION_PROPOSE_REQUEST_METHOD: &str = "wc_sessionPropose";
+/// https://docs.walletconnect.com/2.0/specs/clients/sign/rpc-methods#wc_sessionpropose
+pub const WC_SESSION_PROPOSE_REQUEST_TAG: u32 = 1100;
+/// Method: wc_sessionPropose
+#[derive(Serialize, Deserialize)]
+pub struct WcSessionPropose {
+    #[serde(rename = "requiredNamespaces")]
+    pub(crate) required_namespaces: RequiredNamespaces,
+    #[serde(rename = "optionalNamespaces")]
+    pub(crate) optional_namespaces: OptionalNamespaces,
+    pub(crate) relays: Vec<Relay>,
+    pub(crate) proposer: Peer,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct OptionalNamespaces {
+    // FIXME: eip155 etc.
+}
+
+/// FIXME: is it duplicate with WalletConnect 1.0?
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Metadata {
+    pub description: String,
+    pub url: String,
+    pub icons: Vec<String>,
+    pub name: String,
+}
+
+/// the relay protocol info
+#[derive(Serialize, Deserialize)]
+pub struct Relay {
+    pub(crate) protocol: String,
+}
+
+/// the namespaces required by the dApp / client
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct RequiredNamespaces {
+    pub(crate) eip155: Eip155,
+    // FIXME: Cosmos, Solana, Stellar...
+}
+
+impl RequiredNamespaces {
+    /// Create a new required namespaces.
+    pub fn new(methods: Vec<String>, chains: Vec<String>, events: Vec<String>) -> Self {
+        Self {
+            eip155: Eip155 {
+                methods,
+                chains,
+                events,
+            },
+        }
+    }
+}
+
+/// the required EIP155 namespace
+/// chains are the chain IDs prefixed with "eip155:"
+/// TODO: just store the chain IDs and have custom deserialize/serialize?
+/// TODO: methods/events -- use Enum of known Ethereum methods/events?
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Eip155 {
+    methods: Vec<String>,
+    pub(crate) chains: Vec<String>,
+    events: Vec<String>,
+}
+
+/// The response to the session proposal request.
+#[derive(Serialize, Deserialize)]
+pub struct WcSessionProposeResponse {
+    relay: Relay,
+    #[serde(rename = "responderPublicKey")]
+    pub(crate) responder_public_key: String,
+}
+
+/// Method: wc_sessionSettle
+/// https://docs.walletconnect.com/2.0/specs/clients/sign/rpc-methods#wc_sessionsettle
+#[derive(Serialize, Deserialize)]
+pub struct WcSessionSettle {
+    relay: Relay,
+    pub namespaces: Namespaces,
+    #[serde(rename = "requiredNamespaces")]
+    required_namespaces: RequiredNamespaces,
+    pub controller: Peer,
+    expiry: i64,
+}
+
+/// https://docs.walletconnect.com/2.0/specs/clients/sign/rpc-methods#wc_sessionsettle
+pub const WC_SESSION_SETTLE_RESPONSE_TAG: u32 = 1103;
+
+/// The peer metadata
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Peer {
+    /// public key encoded in hexadecimal
+    #[serde(rename = "publicKey")]
+    pub(crate) public_key: String,
+    pub(crate) metadata: Metadata,
+}
+
+/// The namespaces returned by the wallet
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Namespaces {
+    pub(crate) eip155: NamespacesEip155,
+}
+
+/// The address with EIP155 chain ID
+/// e.g. eip155:1:0x1234567890123456789012345678901234567890
+#[derive(SerializeDisplay, DeserializeFromStr, Debug, Clone)]
+pub struct Eip155AddressWithChainId {
+    pub address: Address,
+    pub chain_id: u64,
+}
+
+impl FromStr for Eip155AddressWithChainId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(':');
+        let prefix = parts.next().ok_or(anyhow::anyhow!("invalid prefix"))?;
+        if prefix != "eip155" {
+            return Err(anyhow::anyhow!("invalid prefix"));
+        }
+        let chain_id = parts.next().ok_or(anyhow::anyhow!("invalid chain id"))?;
+        let chain_id = chain_id.parse::<u64>()?;
+        let address = parts.next().ok_or(anyhow::anyhow!("invalid address"))?;
+        let address = Address::from_str(address)?;
+        Ok(Self { address, chain_id })
+    }
+}
+
+impl Display for Eip155AddressWithChainId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "eip155:{}:{}", self.chain_id, self.address)
+    }
+}
+
+impl Namespaces {
+    pub fn get_ethereum_addresses(&self) -> Vec<Eip155AddressWithChainId> {
+        self.eip155.accounts.clone()
+    }
+}
+
+/// The EIP155 namespace
+/// FIXME: parse events and methods to the known Ethereum events and methods?
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NamespacesEip155 {
+    pub(crate) accounts: Vec<Eip155AddressWithChainId>,
+    pub(crate) methods: Vec<String>,
+    pub(crate) events: Vec<String>,
+}
+
+/// ref: https://docs.walletconnect.com/2.0/specs/clients/sign/rpc-methods#wc_sessionrequest
+pub const WC_SESSION_REQUEST_METHOD: &str = "wc_sessionRequest";
+/// ref: https://docs.walletconnect.com/2.0/specs/clients/sign/rpc-methods#wc_sessionrequest
+pub const WC_SESSION_REQUEST_TAG: u32 = 1108;
+
+/// Method: wc_sessionRequest
+#[derive(Serialize, Deserialize)]
+pub struct WcSessionRequest<T> {
+    request: WcSessionRequestData<T>,
+    #[serde(rename = "chainId")]
+    chain_id: String,
+}
+
+impl<T> WcSessionRequest<T> {
+    pub fn new(method: String, params: T, chain_id: String) -> Self {
+        Self {
+            request: WcSessionRequestData { method, params },
+            chain_id,
+        }
+    }
+}
+
+/// this wraps the RPC requests,
+/// such as https://docs.walletconnect.com/2.0/advanced/rpc-reference/ethereum-rpc
+#[derive(Serialize, Deserialize)]
+pub struct WcSessionRequestData<T> {
+    method: String,
+    params: T,
+    // expiry: Option<u64>,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Request;
+
+    use super::WcSessionSettle;
+
+    #[test]
+    pub fn test_deserialize_wc_settle() {
+        let request = "{\"id\":1678415342621744,\"jsonrpc\":\"2.0\",\"method\":\"wc_sessionSettle\",\"params\":{\"relay\":{\"protocol\":\"irn\"},\"namespaces\":{\"eip155\":{\"accounts\":[\"eip155:5:0xcE915a3b937261853EE2C60B8010c22c295200B0\"],\"methods\":[\"eth_sendTransaction\",\"eth_signTransaction\",\"eth_sign\",\"personal_sign\",\"eth_signTypedData\"],\"events\":[\"chainChanged\",\"accountsChanged\"]}},\"requiredNamespaces\":{\"eip155\":{\"methods\":[\"eth_sendTransaction\",\"eth_signTransaction\",\"eth_sign\",\"personal_sign\",\"eth_signTypedData\"],\"chains\":[\"eip155:5\"],\"events\":[\"chainChanged\",\"accountsChanged\"]}},\"optionalNamespaces\":{},\"controller\":{\"publicKey\":\"94f705551213e83822c9a0c29063bb79223eec36433ad411f2de7bbaa4ae496f\",\"metadata\":{\"name\":\"React Wallet\",\"description\":\"React Wallet for WalletConnect\",\"url\":\"https://walletconnect.com/\",\"icons\":[\"https://avatars.githubusercontent.com/u/37784886\"]}},\"expiry\":1679020142}}";
+        let req: Request<WcSessionSettle> = serde_json::from_str(request).unwrap();
+        let data = req.params;
+        assert_eq!(data.namespaces.eip155.accounts.len(), 1);
+        assert_eq!(data.namespaces.eip155.methods.len(), 5);
+        assert_eq!(data.namespaces.eip155.events.len(), 2);
+        assert_eq!(data.required_namespaces.eip155.methods.len(), 5);
+        assert_eq!(data.required_namespaces.eip155.chains.len(), 1);
+        assert_eq!(data.required_namespaces.eip155.events.len(), 2);
+        assert_eq!(
+            data.namespaces.eip155.accounts[0].address,
+            "0xcE915a3b937261853EE2C60B8010c22c295200B0"
+                .parse()
+                .unwrap()
+        );
+    }
+}

--- a/wallet-connect/src/v2/session.rs
+++ b/wallet-connect/src/v2/session.rs
@@ -1,0 +1,134 @@
+use relay_rpc::domain::Topic;
+use secrecy::ExposeSecret;
+use serde::{Deserialize, Serialize};
+use url::Url;
+use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::Zeroize;
+
+use crate::{crypto::Key, hex};
+
+use super::{
+    crypto::derive_symkey_topic,
+    protocol::{
+        Namespaces, OptionalNamespaces, Peer, Relay, RequiredNamespaces, WcSessionPropose,
+        WcSessionProposeResponse, WcSessionSettle,
+    },
+    Metadata,
+};
+
+/// The WalletConnect 2.0 session information
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInfo {
+    /// if the wallet approved the connection
+    pub connected: bool,
+    /// namespaces required by the client
+    pub required_namespaces: RequiredNamespaces,
+    /// the accounts, methods, and events returned by the wallet
+    pub namespaces: Option<Namespaces>,
+    /// the relay server URL
+    pub relay_server: Url,
+    /// the project id for the walletconnect v2
+    pub project_id: String,
+    /// the secret key used in encrypting the session proposal request
+    pub session_proposal_symkey: Key,
+    /// this is the client's secret key for a pairing topic derivation
+    pub client_secret_key: Key,
+    /// the client metadata (that will be presented to the wallet in the initial request)
+    pub client_meta: Peer,
+    /// the topic derived from the wallet's public key
+    /// and the secret key used in encrypting the paired session requests
+    pub pairing_topic_symkey: Option<(Topic, Key)>,
+    /// the wallet's metadata
+    pub pairing_peer_meta: Option<Peer>,
+    /// the one-time request ID
+    pub session_proposal_topic: Topic,
+}
+
+impl SessionInfo {
+    /// Create a new session info.
+    /// it will generate a new secret key for the session proposal,
+    /// a new secret key for the pairing topic,
+    /// a new topic for the session proposal
+    /// and prepare the client/peer metadata from it
+    /// and provided arguments.
+    pub fn new(
+        relay_server: Url,
+        project_id: String,
+        required_namespaces: RequiredNamespaces,
+        metadata: Metadata,
+    ) -> Self {
+        let mut client_secret = StaticSecret::new(relay_rpc::auth::rand::thread_rng());
+        let client_public = PublicKey::from(&client_secret);
+        let client_secret_key = Key::from_raw(client_secret.to_bytes());
+        client_secret.zeroize();
+        let session_proposal_symkey = Key::random();
+
+        let session_proposal_topic = Topic::generate();
+        let client_meta = Peer {
+            public_key: hex::encode(client_public.as_bytes()),
+            metadata,
+        };
+        Self {
+            connected: false,
+            required_namespaces,
+            namespaces: None,
+            relay_server,
+            project_id,
+            session_proposal_symkey,
+            client_secret_key,
+            client_meta,
+            pairing_topic_symkey: None,
+            pairing_peer_meta: None,
+            session_proposal_topic,
+        }
+    }
+
+    /// Return the URI for the initial session proposal request
+    /// (usually displayed in a QR code or used via a deep link).
+    /// ref: https://docs.walletconnect.com/2.0/specs/clients/core/pairing/pairing-uri
+    ///
+    /// FIXME: currently, it doesn't include the "required methods"
+    /// such as &methods=[wc_sessionPropose],[wc_authRequest,wc_authBatchRequest]
+    /// but it seems the test react wallet works without it
+    pub fn uri(&self) -> String {
+        // FIXME: methods
+        format!(
+            "wc:{}@2?symKey={}&relay-protocol=irn",
+            self.session_proposal_topic,
+            self.session_proposal_symkey.display().expose_secret()
+        )
+    }
+
+    /// Return the session proposal request payload
+    pub fn session_proposal(&self) -> WcSessionPropose {
+        WcSessionPropose {
+            required_namespaces: self.required_namespaces.clone(),
+            optional_namespaces: OptionalNamespaces {},
+            relays: vec![Relay {
+                protocol: "irn".to_string(),
+            }],
+            proposer: self.client_meta.clone(),
+        }
+    }
+
+    /// Update the session based on the session proposal response
+    /// and return the topic for the pairing topic
+    /// if the response is valid
+    pub fn session_proposal_response(
+        &mut self,
+        propose_response: &WcSessionProposeResponse,
+    ) -> Option<Topic> {
+        self.pairing_topic_symkey = derive_symkey_topic(
+            &propose_response.responder_public_key,
+            &self.client_secret_key,
+        );
+        self.pairing_topic_symkey.as_ref().map(|(x, _)| x.clone())
+    }
+
+    /// Update the session based on the session settle response
+    pub fn session_settle(&mut self, settle: WcSessionSettle) {
+        self.pairing_peer_meta = Some(settle.controller);
+        self.namespaces = Some(settle.namespaces);
+    }
+}


### PR DESCRIPTION
Solution:
- added a quick hacky implementation of a part of Sign API using the fork of WIP Rust SDK

notes:
- the implementation is incomplete, e.g. many session management https://docs.walletconnect.com/2.0/specs/clients/sign/rpc-methods methods are missing
- the fork is done to use rustls in websockets + async trait for the message handler
- only limited testing with the sample react wallet (i.e. there may be bugs)
- some copy-paste from v1 and non-ideal code
- no bindings or callbacks yet