### PR TITLE
Problem: missing msys2 compile script (fix #422)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 *.swp
+demo/demo/demo.vcxproj.user
+demo/demo/x64/
+demo/out/
+demo/demostatic/x64/ 
+demo/.vs
 demo/bin/
 demo/*.h
 demo/*.cc

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQURIED ON)
+set(CMAKE_CXX_STANDARD_REQUIRED  ON)
 set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "" FORCE)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 if (APPLE)
@@ -22,7 +22,10 @@ add_subdirectory(sdk)
 
 # add static demo
 add_executable(demostatic main.cc chainmain.cc cronos.cc extra.cc third_party/easywsclient/easywsclient.cpp)
-if (WIN32)
+if (WIN32 AND MSYS)
+  target_link_libraries(demostatic PUBLIC ${PLAY_CPP_SDK_LIB} Ncrypt userenv ntdll Secur32 crypt32 ws2_32 ntdll)
+endif()
+if (WIN32 AND NOT MSYS)
   target_link_libraries(demostatic PUBLIC ${PLAY_CPP_SDK_LIB} Ncrypt userenv ntdll Secur32 crypt32)
 endif()
 if (APPLE)
@@ -34,7 +37,10 @@ endif()
 
 # add dynamic demo
 add_executable(demo main.cc chainmain.cc cronos.cc extra.cc third_party/easywsclient/easywsclient.cpp)
-if (WIN32)
+if (WIN32 AND MSYS)
+  target_link_libraries(demo PUBLIC ${PLAY_CPP_SDK_LIB} Ncrypt userenv ntdll Secur32 crypt32 ws2_32 ntdll)
+endif()
+if (WIN32 AND NOT MSYS)
   target_link_libraries(demo PUBLIC play_cpp_sdk)
   # Copy dll
   add_custom_command(TARGET demo

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -77,6 +77,18 @@ endif
 
 static: easywsclient.o
 	mkdir -p bin
+ifeq ($(MSYSTEM), MINGW64)
+	$(CXX) -o bin/demostatic \
+		easywsclient.o \
+		main.cc \
+		chainmain.cc \
+		cronos.cc \
+		extra.cc \
+		$(sdk_dir)/lib/libplay_cpp_sdk.a \
+		-lws2_32 -lntdll \
+		-lcrypt32 -lsecur32 -lbcrypt -luserenv -lncrypt \
+		-std=c++14 $(FLAGS) 
+else
 	$(CXX) -o bin/demostatic \
 		easywsclient.o \
 		main.cc \
@@ -85,6 +97,7 @@ static: easywsclient.o
 		extra.cc \
 		$(sdk_dir)/lib/libplay_cpp_sdk.a \
 		-std=c++14 $(FLAGS)
+endif 
 
 dynamic: easywsclient.o libplay_cpp_sdk.so libplay_cpp_sdk.dylib
 	mkdir -p bin

--- a/demo/helper.py
+++ b/demo/helper.py
@@ -117,11 +117,19 @@ def copy_cxxbridge(output_path):
 def copy_lib_files(output_path):
     os.makedirs(output_path, exist_ok=True)
     files = []
-    if platform.system() == 'Windows':
-        files.extend(collect_files("*.lib", TARGET_DIR, recursive=False))
-        files.extend(collect_files("*.dll", TARGET_DIR, recursive=False))
-        # workaround: search libcxxbridge1.lib and push the first one
-        files.append(collect_files("cxxbridge1.lib", TARGET_DIR)[0])
+    # when msys updated, platform.system() returns 'MINGW64_NT-10.0-19042'
+    if platform.system() == 'Windows' or platform.system().startswith('MINGW64'):       
+        # if msys2, copy *.a files
+        if 'MINGW64' in os.environ.get('MSYSTEM', ''): # msys2
+            # need to copy libplay_cpp_sdk.a for msys2 
+            # *.lib files are for msvc, not compatible with msys2
+            files.extend(collect_files("*.a", TARGET_DIR, recursive=False))
+            files.append(collect_files("libcxxbridge1.a", TARGET_DIR)[0])
+        else: #msvc
+            files.extend(collect_files("*.lib", TARGET_DIR, recursive=False))
+            files.extend(collect_files("*.dll", TARGET_DIR, recursive=False))
+            # workaround: search libcxxbridge1.lib and push the first one
+            files.append(collect_files("cxxbridge1.lib", TARGET_DIR)[0])
     elif platform.system() == 'Linux':
         files.extend(collect_files("*.a", TARGET_DIR, recursive=False))
         # TODO support *.so

--- a/demo/sdk/CMakeLists.txt
+++ b/demo/sdk/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQURIED ON)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(play_cpp_sdk VERSION 0.0.1)
 
@@ -13,13 +13,22 @@ file(GLOB PLAY_CPP_SDK_SROUCES include/*.cc)
 find_library(RUST_LIB cxxbridge1 REQUIRED PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
 # Find the prebuilt static and dynamic libraries
-if (WIN32)
+if (WIN32 AND MSYS)
+  find_library(PLAY_CPP_SDK_LIB libplay_cpp_sdk.a PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+  find_library(PLAY_CPP_SDK_DYLIB libplay_cpp_sdk.dll.a PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+  find_file(PLAY_CPP_SDK_DLL NAME play_cpp_sdk.dll PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+  # Add static library play_cpp_sdk built from bindings source files
+  add_library(play_cpp_sdk STATIC ${DEFI_WALLET_CORE_CPP_BINDINGS} ${EXTRA_CPP_BINDINGS} ${PLAY_CPP_SDK_SROUCES})
+  target_link_libraries(play_cpp_sdk ${PLAY_CPP_SDK_LIB} Ncrypt userenv ntdll Secur32 crypt32 ws2_32 ntdll)
+endif()
+
+if (WIN32 AND NOT MSYS)
   find_library(PLAY_CPP_SDK_LIB play_cpp_sdk.lib PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
   find_library(PLAY_CPP_SDK_DYLIB play_cpp_sdk.dll.lib PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
   find_file(PLAY_CPP_SDK_DLL NAME play_cpp_sdk.dll PATHS ${CMAKE_CURRENT_SOURCE_DIR}/lib)
   # Add static library play_cpp_sdk built from bindings source files
   add_library(play_cpp_sdk STATIC ${DEFI_WALLET_CORE_CPP_BINDINGS} ${EXTRA_CPP_BINDINGS} ${PLAY_CPP_SDK_SROUCES})
-  target_link_libraries(play_cpp_sdk ${RUST_LIB} ${PLAY_CPP_SDK_DYLIB} Ncrypt userenv ntdll Secur32 crypt32)
+  target_link_libraries(play_cpp_sdk ${PLAY_CPP_SDK_LIB} Ncrypt userenv ntdll Secur32 crypt32 ws2_32 ntdll)
 endif()
 
 if (APPLE)

--- a/msys_build.sh
+++ b/msys_build.sh
@@ -1,0 +1,27 @@
+# use rust like this
+# pacman -S --needed mingw-w64-x86_64-toolchain mingw-w64-x86_64-rust
+# msvc rust is not compatible with msys2 
+
+# bring all source
+git config --global core.symlinks true
+git submodule update --init --recursive
+
+# fix for msys2
+sed -i 's/typedef __int8 int8_t;/\/\/ typedef __int8 int8_t;/' ./demo/third_party/easywsclient/easywsclient.cpp
+
+# prepare
+cargo build --release
+
+# copy library
+cd ./demo
+python ./helper.py
+cd ..
+
+# compile
+mkdir -p ./demo/build
+cd ./demo/build
+cmake -G "MSYS Makefiles" ..
+make
+cd ../..
+echo "OK"
+


### PR DESCRIPTION
- support msys2
- fix msvc build batchfile
- fix typo in cmake

checked on
-linux, mac, windows msvc (visual studio 2019), windows msys2