### PR TITLE
Problem: not using webpki tls (fix #429)

### DIFF
--- a/wallet-connect/Cargo.toml
+++ b/wallet-connect/Cargo.toml
@@ -38,7 +38,7 @@ quickcheck = "1"
 quickcheck_macros = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio-tungstenite = { version = "0.18", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.18", features = ["rustls-tls-webpki-roots"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 uuid = { version = "1.3", features = ["serde", "v4"] }
 


### PR DESCRIPTION
Solution: 
change rustls-tls-native-roots to rustls-tls-webpki-roots

to fix UnsupportedCriticalExtension error